### PR TITLE
Corrected the displaying of the total allowance for a given user

### DIFF
--- a/src/main/resources/templates/shopping.html
+++ b/src/main/resources/templates/shopping.html
@@ -53,7 +53,7 @@
 						<span th:text="*{name} + ':'" />
 						<span class="amountUsed" th:text="${cart.allowanceUsed(currency)}" />
 						<span>/</span>
-						<span class="allowance" th:text="${currency.allowanceOf(user.familySize)}" />
+						<span class="allowance" th:text="${currency.allowanceOf(user)}" />
 						<span th:text="*{unit}">
 					</p>
 				</div>


### PR DESCRIPTION
Turns out Thymeleaf was calling the overloaded method of allowanceOf which happened to be private. It was supposed to receive a PantryUser but instead it was getting the familySize. I believe the public allowanceOf which took a PantryUser was somehow using the int to get a user by its long id and then return the allowanceOf for that user. Or I could be totally wrong, either way it's fixed now.